### PR TITLE
bugfix: Only kill players

### DIFF
--- a/src/main/kotlin/us/timinc/mc/cobblemon/whiteout/Whiteout.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/whiteout/Whiteout.kt
@@ -1,5 +1,6 @@
 package us.timinc.mc.cobblemon.whiteout
 
+import com.cobblemon.mod.common.api.battles.model.actor.ActorType
 import com.cobblemon.mod.common.api.events.CobblemonEvents
 import com.cobblemon.mod.common.api.events.battles.BattleFaintedEvent
 import net.fabricmc.api.ModInitializer
@@ -15,6 +16,11 @@ object Whiteout : ModInitializer {
         val killed = battleFaintedEvent.killed
         val entity = killed.entity ?: return
         val owner = entity.owner ?: return
+
+        if (killed.actor.type == ActorType.NPC) {
+            return
+        }
+
         if (killed.actor.pokemonList.all { it.health == 0 }) {
             owner.kill()
         }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/whiteout/Whiteout.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/whiteout/Whiteout.kt
@@ -16,11 +16,7 @@ object Whiteout : ModInitializer {
         val killed = battleFaintedEvent.killed
         val entity = killed.entity ?: return
         val owner = entity.owner ?: return
-
-        if (killed.actor.type == ActorType.NPC) {
-            return
-        }
-
+        if (killed.actor.type != ActorType.PLAYER) return
         if (killed.actor.pokemonList.all { it.health == 0 }) {
             owner.kill()
         }


### PR DESCRIPTION
Fix prevents NPC's getting killed.

Effectually fixes RCT trainers mod progression, for example