### PR TITLE
v1.2.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ yarn_mappings=1.21.1+build.3
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.6-fabric-1.2.1
+mod_version=1.6-fabric-1.2.2
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=whiteout
 

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_armor.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_armor.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "cobblemon-whiteout:fled",
+    "cobblemon-whiteout:pokebattle"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_effects.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_effects.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "cobblemon-whiteout:fled",
+    "cobblemon-whiteout:pokebattle"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_invulnerability.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_invulnerability.json
@@ -1,7 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "cobblemon-whiteout:fled",
-    "cobblemon-whiteout:pokebattle"
-  ]
-}

--- a/src/main/resources/data/minecraft/tags/damage_type/bypasses_invulnerability.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/bypasses_invulnerability.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "cobblemon-whiteout:fled",
+    "cobblemon-whiteout:pokebattle"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/damage_type/damage_is_absolute.json
+++ b/src/main/resources/data/minecraft/tags/damage_type/damage_is_absolute.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "cobblemon-whiteout:fled",
+    "cobblemon-whiteout:pokebattle"
+  ]
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "cobblemon-whiteout",
-  "version": "1.6-fabric-1.2.1",
+  "version": "1.6-fabric-1.2.2",
   "name": "Cobblemon Whiteout",
   "description": "What if players whited out if their last Pokemon fainted?",
   "authors": [


### PR DESCRIPTION
* Custom damage types now bypass armor (so they don't break it), as well as effects, and the damage is a flat number.